### PR TITLE
Use utf-8 encoding for transcription.txt

### DIFF
--- a/transcriber.py
+++ b/transcriber.py
@@ -221,7 +221,7 @@ def main(page: ft.Page):
             draggable_area2.visible = False
 
             # Save transcription.
-            with open(transcription_file, 'w+') as f:
+            with open(transcription_file, 'w+', encoding='utf-8') as f:
                 f.writelines('\n'.join([item.value for item in transcription_list.controls]))
 
             currently_transcribing = False


### PR DESCRIPTION
Fix for application crash after clicking 'Stop Transcribing' when the transcription language is set to many non-English languages that need utf-8 characters.
