### PR TITLE
Fix bug `int object is not callable`

### DIFF
--- a/transcriber.py
+++ b/transcriber.py
@@ -123,7 +123,7 @@ def main(page: ft.Page):
             if (not audio_model or not loaded_audio_model) or ((audio_model and loaded_audio_model) and loaded_audio_model != model):
                 device = 'cpu'
                 if torch.has_cuda:
-                    device = 0
+                    device = "cuda"
                 audio_model = whisper.load_model(model, device)
                 loaded_audio_model = model
 


### PR DESCRIPTION
This is what was causing infinite loading for me. Seems like at least on newer pythons (I tested on py3.9) we need to set a string. Closes #2 

Btw it would be helpful to not suppress all the outputs